### PR TITLE
MAINT: add env file for QIIME 2 2026.1

### DIFF
--- a/environment-files/q2-minimap2-qiime2-amplicon-2026.1.yml
+++ b/environment-files/q2-minimap2-qiime2-amplicon-2026.1.yml
@@ -1,0 +1,13 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/amplicon/released  
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2-amplicon
+  - minimap2
+  - samtools
+  - q2-feature-classifier
+  - q2-types
+  - pip
+  - pip:
+    - q2-minimap2@git+https://github.com/bokulich-lab/q2-minimap2.git@2026.1.0

--- a/environment-files/q2-minimap2-qiime2-moshpit-2026.1.yml
+++ b/environment-files/q2-minimap2-qiime2-moshpit-2026.1.yml
@@ -1,0 +1,13 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/moshpit/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2-moshpit
+  - minimap2
+  - samtools
+  - q2-feature-classifier
+  - q2-types
+  - pip
+  - pip:
+    - q2-minimap2@git+https://github.com/bokulich-lab/q2-minimap2.git@2026.1.0


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2026.1.

Generated from the latest env file in 'environment-files/' by updating the release token.